### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Well, apparently SDWebImage team [doesn't want](https://github.com/rs/SDWebImage
 
 **And why a category instead of a fork?** Well, I really don't want to keep this repo updated with the (future) new SDWebImage commits (obvious, right?).  
 
-**Ok, but  we could modify our SDWebImage repo with these differences** Yes... unless you're using Cocoapods! If you're doing it you should know that you can't modify a repo, because at the next update, Cocoapods will delete all your work (pulling the new version and removing all your changes). So with a category you can keep your SDWebImage pod updated without problems :) 
+**Ok, but  we could modify our SDWebImage repo with these differences** Yes... unless you're using CocoaPods! If you're doing it you should know that you can't modify a repo, because at the next update, CocoaPods will delete all your work (pulling the new version and removing all your changes). So with a category you can keep your SDWebImage pod updated without problems :) 
 
 
 License


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
