### PR TITLE
Adição do path completo dos arquivos importados de SDWebImage

### DIFF
--- a/UIActivityIndicator-for-SDWebImage+UIButton.podspec
+++ b/UIActivityIndicator-for-SDWebImage+UIButton.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name          = "UIActivityIndicator-for-SDWebImage+UIButton"
-  s.version       = "1.2"
+  s.version       = "1.2.1"
   s.summary       = "The easiest way to add a UIActivityView to your SDWebImage view."
   s.description   = 'A category that easily allows you to use a UIActivityIndicator in SDWebImage in both UIImageView and UIButton.'
-  s.homepage      = "https://github.com/nobre84/UIActivityIndicator-for-SDWebImage"
+  s.homepage      = "https://github.com/qranio-com/UIActivityIndicator-for-SDWebImage"
   s.license       = { :type => 'MIT License', :file => 'LICENSE.txt' }
   s.author        = { "Rafael Nobre" => "nobre84@gmail.com" }
-  s.source        = { :git => "https://github.com/nobre84/UIActivityIndicator-for-SDWebImage.git", :tag => "v1.2" }
+  s.source        = { :git => "https://github.com/qranio-com/UIActivityIndicator-for-SDWebImage.git", :tag => s.version.to_s }
   s.platform      = :ios, '5.0'
   s.source_files  = '*.{h,m}'
   s.requires_arc  = true

--- a/UIButton+UIActivityIndicatorForSDWebImage.h
+++ b/UIButton+UIActivityIndicatorForSDWebImage.h
@@ -7,8 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "UIButton+WebCache.h"
-#import "SDImageCache.h"
+#import "SDWebImage/UIButton+WebCache.h"
+#import "SDWebImage/SDImageCache.h"
 
 @interface UIButton (UIActivityIndicatorForSDWebImage)
 

--- a/UIImageView+UIActivityIndicatorForSDWebImage.h
+++ b/UIImageView+UIActivityIndicatorForSDWebImage.h
@@ -7,8 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "UIImageView+WebCache.h"
-#import "SDImageCache.h"
+#import "SDWebImage/UIImageView+WebCache.h"
+#import "SDWebImage/SDImageCache.h"
 
 @interface UIImageView (UIActivityIndicatorForSDWebImage)
 


### PR DESCRIPTION
Adição do path completo dos arquivos importados de SDWebImage. Pois ao utilizar como dependência de um framework e/ou fazer pod lib lint, ocorrem vários erros de compilação
